### PR TITLE
Correct URI generation for next steps; introduce resources explicitly

### DIFF
--- a/llm-prompts/basic-integration/1.1-edit.md
+++ b/llm-prompts/basic-integration/1.1-edit.md
@@ -11,7 +11,7 @@ If a file already has existing integration code for other tools or services, don
 
 For each event, add useful properties, and use your access to the PostHog source code to ensure correctness. You also have access to documentation about creating new events with PostHog. Consider this documentation carefully and follow it closely before adding events. Your integration should be based on documented best practices. Carefully consider how the user project's framework version may impact the correct PostHog integration approach.
 
-Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names.
+Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names. There are also example project code files available via the PostHog MCP; use these for reference.
 
 Where possible, add calls for PostHog's identify() function on the client side. On the server side, make sure events have a matching distinct ID where relevant. Use the same ID for identify on the client as you use distinct ID on the server. Logins and signups are a great opportunity to identify users. Use the contents of login and signup forms to identify users on submit.
 


### PR DESCRIPTION
Amusingly, the URI format generated to glue workflows together was incorrect.

The agent could recover by listing resources and picking the one that matched closest. this happens consistently and so we got away with it, but obviously that's a waste of inference. This fixes that, by centralizing all the places where we generate URIs, and adds some explicit prompting in the basic integration to remember that example code is available.

Tested with a local wizard, local MCP run and validated in the logs.