### PR TITLE
Admonish against using PostHogProvider components in Next 15.3+

### DIFF
--- a/basics/next-app-router/instrumentation-client.ts
+++ b/basics/next-app-router/instrumentation-client.ts
@@ -15,3 +15,5 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   opt_out_useragent_filter: true,  // This disables bot detection
   // @ignoreBlockEnd
 });
+
+//IMPORTANT: Never combine this approach with other client-side PostHog initialization approaches, especially components like a PostHogProvider. instrumentation-client.ts is the correct solution for initializating client-side PostHog in Next.js 15.3+ apps.

--- a/basics/next-pages-router/instrumentation-client.ts
+++ b/basics/next-pages-router/instrumentation-client.ts
@@ -15,3 +15,5 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   opt_out_useragent_filter: true,  // This disables bot detection
   // @ignoreBlockEnd
 });
+
+//IMPORTANT: Never combine this approach with other client-side PostHog initialization approaches, especially components like a PostHogProvider. instrumentation-client.ts is the correct solution for initializating client-side PostHog in Next.js 15.3+ apps.


### PR DESCRIPTION
I just saw the robot add _both_ `instrumentation-client.ts` AND a `PostHogProvider` component. This adds a comment to discourage this behavior in an appropriate place: `instrumentation-client.ts`!